### PR TITLE
Fix scanned QR code validation

### DIFF
--- a/lib/UI/node_config_screen.dart
+++ b/lib/UI/node_config_screen.dart
@@ -194,7 +194,7 @@ class _NodeConfigFormState extends State<NodeConfigForm> {
   }
 
   void _setConfigFormFields(String data) async {
-    if (data.isEmpty && data.toLowerCase().contains('error') || data == '-1')
+    if (data.isEmpty || data.toLowerCase().contains('error') || data == '-1')
       return;
 
     try {


### PR DESCRIPTION
## Summary
- avoid crashing when scanning invalid QR codes

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883b261d538832487edb368c88c91bf