### PR TITLE
Improve app initialization and RPC helpers

### DIFF
--- a/lib/UI/dashboard_screen.dart
+++ b/lib/UI/dashboard_screen.dart
@@ -91,18 +91,18 @@ class DashboardScreen extends ConsumerWidget {
                           if (_selectedIndex == 1)
                             IconButton(
                                 onPressed: () {
-                                  Navigate.toRoute(Navigator.pushReplacement(
-                                      context,
-                                      MaterialPageRoute(
-                                        builder: (context) =>
-                                            OpenChannelProvider(),
-                                      )));
+                                  Navigate.toRoute(() => Navigator.pushReplacement(
+                                        context,
+                                        MaterialPageRoute(
+                                          builder: (context) =>
+                                              OpenChannelProvider(),
+                                        )));
                                 },
                                 icon: Icon(
                                   Icons.add,
                                 )),
                           IconButton(
-                              onPressed: () => Navigate.toRoute(
+                              onPressed: () => Navigate.toRoute(() =>
                                   Navigator.pushReplacement(
                                       context,
                                       MaterialPageRoute(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,9 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../UI/dashboard_screen.dart';
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
-import 'constants/node_setting.dart';
-import 'database/secure_storage.dart';
-import 'rpc/lnd.dart';
+import 'services/app_initializer.dart';
 import 'util/app_colors.dart';
 
 void main() {
@@ -13,23 +11,22 @@ void main() {
   runApp(ProviderScope(child: const PlebLN()));
 }
 
-class PlebLN extends ConsumerWidget {
+class PlebLN extends ConsumerStatefulWidget {
   const PlebLN({Key? key}) : super(key: key);
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    initAppData() async {
-      String result =
-          await SecureStorage.readValue(NodeSetting.isConfigured.name) ??
-              'false';
-      bool isConfigured = false;
-      result == 'true' ? isConfigured = true : isConfigured = false;
-      if (isConfigured) {
-        await LND.fetchEssentialData(ref);
-      }
-    }
+  ConsumerState<PlebLN> createState() => _PlebLNState();
+}
 
-    initAppData();
+class _PlebLNState extends ConsumerState<PlebLN> {
+  @override
+  void initState() {
+    super.initState();
+    AppInitializer.initialize(ref);
+  }
+
+  @override
+  Widget build(BuildContext context) {
     return MaterialApp(
       debugShowCheckedModeBanner: false,
       theme: ThemeData(

--- a/lib/rpc/lnd.dart
+++ b/lib/rpc/lnd.dart
@@ -14,6 +14,16 @@ class LND {
   static Future<LightningClient> get _lightningStub => createLightningClient();
   static Future<RouterClient> get _routerStub => createRouterClient();
 
+  static Future<T> _executeRpc<T>(Future<T> Function() call) async {
+    try {
+      return await call();
+    } on GrpcError catch (ex) {
+      throw Exception(ex.message);
+    } catch (ex) {
+      throw Exception(ex);
+    }
+  }
+
   static Future<LightningClient> createLightningClient() async {
     String host = await SecureStorage.readValue(NodeSetting.host.name) ?? '';
     String gRPCPort =
@@ -89,127 +99,53 @@ class LND {
   }
 
   Future<GetInfoResponse> getInfo() async {
-    GetInfoResponse response = GetInfoResponse();
     LightningClient stub = await _lightningStub;
-    try {
-      response = await stub.getInfo(GetInfoRequest());
-    } on GrpcError catch (ex) {
-      throw Exception(ex.message);
-    } catch (ex) {
-      throw Exception(ex);
-    }
-
-    return response;
+    return _executeRpc(() => stub.getInfo(GetInfoRequest()));
   }
 
   Future<WalletBalanceResponse> getWalletBalance() async {
-    WalletBalanceResponse response = WalletBalanceResponse();
     LightningClient stub = await _lightningStub;
-    try {
-      response =
-          await stub.walletBalance(WalletBalanceRequest(), CallOptions());
-    } on GrpcError catch (ex) {
-      throw Exception(ex.message);
-    } catch (ex) {
-      throw Exception(ex);
-    }
-
-    return response;
+    return _executeRpc(
+        () => stub.walletBalance(WalletBalanceRequest(), CallOptions()));
   }
 
   Future<ChannelBalanceResponse> getChannelBalance() async {
-    ChannelBalanceResponse response = ChannelBalanceResponse();
     LightningClient stub = await _lightningStub;
-    try {
-      response = await stub.channelBalance(ChannelBalanceRequest());
-    } on GrpcError catch (ex) {
-      throw Exception(ex.message);
-    } catch (ex) {
-      throw Exception(ex);
-    }
-
-    return response;
+    return _executeRpc(() => stub.channelBalance(ChannelBalanceRequest()));
   }
 
   Future<ListPaymentsResponse> getPayments() async {
-    ListPaymentsResponse response = ListPaymentsResponse();
     LightningClient stub = await _lightningStub;
-    try {
-      response = await stub.listPayments(ListPaymentsRequest());
-    } on GrpcError catch (ex) {
-      throw Exception(ex.message);
-    } catch (ex) {
-      throw Exception(ex);
-    }
-
-    return response;
+    return _executeRpc(() => stub.listPayments(ListPaymentsRequest()));
   }
 
   Future<ListInvoiceResponse> listInvoices() async {
-    ListInvoiceResponse response = ListInvoiceResponse();
     LightningClient stub = await _lightningStub;
-    try {
-      response = await stub.listInvoices(ListInvoiceRequest());
-    } on GrpcError catch (ex) {
-      throw Exception(ex.message);
-    } catch (ex) {
-      throw Exception(ex);
-    }
-
-    return response;
+    return _executeRpc(() => stub.listInvoices(ListInvoiceRequest()));
   }
 
   Future<ListChannelsResponse> getChannels() async {
-    ListChannelsResponse response = ListChannelsResponse();
     LightningClient stub = await _lightningStub;
-    try {
-      response = await stub.listChannels(ListChannelsRequest());
-    } on GrpcError catch (ex) {
-      throw Exception(ex.message);
-    } catch (ex) {
-      throw Exception(ex);
-    }
-
-    return response;
+    return _executeRpc(() => stub.listChannels(ListChannelsRequest()));
   }
 
   Future<PendingChannelsResponse> getPendingChannels() async {
-    PendingChannelsResponse response = PendingChannelsResponse();
     LightningClient stub = await _lightningStub;
-    try {
-      response = await stub.pendingChannels(PendingChannelsRequest());
-    } on GrpcError catch (ex) {
-      throw Exception(ex.message);
-    } catch (ex) {
-      throw Exception(ex);
-    }
-
-    return response;
+    return _executeRpc(() => stub.pendingChannels(PendingChannelsRequest()));
   }
 
   Future<AddInvoiceResponse> createInvoice(
       Int64 value, String? memo, Int64? expiry) async {
-    AddInvoiceResponse response = AddInvoiceResponse();
     LightningClient stub = await _lightningStub;
-
-    try {
-      response = await stub
-          .addInvoice(Invoice(value: value, memo: memo, expiry: expiry));
-    } on GrpcError catch (ex) {
-      throw Exception(ex.message);
-    } catch (ex) {
-      throw Exception(ex);
-    }
-
-    return response;
+    return _executeRpc(() => stub
+        .addInvoice(Invoice(value: value, memo: memo, expiry: expiry)));
   }
 
   Future<Invoice> invoiceSubscription(
       InvoiceSubscription invoiceSubscription) async {
-    Invoice response = Invoice();
     LightningClient stub = await _lightningStub;
-
-    try {
+    return _executeRpc(() async {
+      Invoice response = Invoice();
       await for (Invoice event in stub.subscribeInvoices(invoiceSubscription,
           options: CallOptions(timeout: Duration(days: 1)))) {
         if (event.addIndex == invoiceSubscription.addIndex &&
@@ -218,109 +154,49 @@ class LND {
           break;
         }
       }
-    } on GrpcError catch (ex) {
-      throw Exception(ex.message);
-    } catch (ex) {
-      throw Exception(ex);
-    }
-
-    return response;
+      return response;
+    });
   }
 
   Future<PayReq> decodePaymentRequest(PayReqString payReqStr) async {
-    PayReq response = PayReq();
     LightningClient stub = await _lightningStub;
-
-    try {
-      response = await stub.decodePayReq(payReqStr);
-    } on GrpcError catch (ex) {
-      throw Exception(ex.message);
-    } catch (ex) {
-      throw Exception(ex);
-    }
-
-    return response;
+    return _executeRpc(() => stub.decodePayReq(payReqStr));
   }
 
   Future<Payment> sendPaymentV2(SendPaymentRequest sendPaymentRequest) async {
-    Payment response = Payment();
     RouterClient stub = await _routerStub;
-    List<Payment> paymentList = [];
-    try {
+    return _executeRpc(() async {
+      List<Payment> paymentList = [];
       await for (Payment payment in stub.sendPaymentV2(sendPaymentRequest)) {
         paymentList.add(payment);
       }
-      response = paymentList.last;
-    } on GrpcError catch (ex) {
-      throw Exception(ex.message);
-    } catch (ex) {
-      throw Exception(ex);
-    }
-
-    return response;
+      return paymentList.last;
+    });
   }
 
   Future<FeeReportResponse> feeReport() async {
-    FeeReportResponse response = FeeReportResponse();
     LightningClient stub = await _lightningStub;
-
-    try {
-      response = await stub.feeReport(FeeReportRequest());
-    } on GrpcError catch (ex) {
-      throw Exception(ex.message);
-    } catch (ex) {
-      throw Exception(ex);
-    }
-
-    return response;
+    return _executeRpc(() => stub.feeReport(FeeReportRequest()));
   }
 
   Future<PolicyUpdateResponse> updateChannelPolicy(
       PolicyUpdateRequest policyUpdateRequest) async {
-    PolicyUpdateResponse response = PolicyUpdateResponse();
     LightningClient stub = await _lightningStub;
-
-    try {
-      response = await stub.updateChannelPolicy(policyUpdateRequest);
-    } on GrpcError catch (ex) {
-      throw Exception(ex.message);
-    } catch (ex) {
-      throw Exception(ex);
-    }
-
-    return response;
+    return _executeRpc(() => stub.updateChannelPolicy(policyUpdateRequest));
   }
 
   Future<CloseStatusUpdate> closeChannel(
       CloseChannelRequest closeChannelRequest) async {
-    CloseStatusUpdate response = CloseStatusUpdate();
     LightningClient stub = await _lightningStub;
-
-    try {
-      response = await stub.closeChannel(closeChannelRequest).first;
-    } on GrpcError catch (ex) {
-      throw Exception(ex.message);
-    } catch (ex) {
-      throw Exception(ex);
-    }
-
-    return response;
+    return _executeRpc(
+        () => stub.closeChannel(closeChannelRequest).first);
   }
 
   Future<OpenStatusUpdate> openChannel(
       OpenChannelRequest openChannelRequest) async {
-    OpenStatusUpdate response = OpenStatusUpdate();
     LightningClient stub = await _lightningStub;
-
-    try {
-      response = await stub.openChannel(openChannelRequest).first;
-    } on GrpcError catch (ex) {
-      throw Exception(ex.message);
-    } catch (ex) {
-      throw Exception(ex);
-    }
-
-    return response;
+    return _executeRpc(
+        () => stub.openChannel(openChannelRequest).first);
   }
 
   static Future<bool> fetchEssentialData(WidgetRef ref) async {

--- a/lib/services/app_initializer.dart
+++ b/lib/services/app_initializer.dart
@@ -1,0 +1,17 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../database/secure_storage.dart';
+import '../constants/node_setting.dart';
+import '../rpc/lnd.dart';
+
+/// Handles application start up logic.
+class AppInitializer {
+  /// Reads the stored configuration and fetches essential data if available.
+  static Future<void> initialize(WidgetRef ref) async {
+    final result =
+        await SecureStorage.readValue(NodeSetting.isConfigured.name) ?? 'false';
+    final isConfigured = result == 'true';
+    if (isConfigured) {
+      await LND.fetchEssentialData(ref);
+    }
+  }
+}

--- a/lib/util/navigate.dart
+++ b/lib/util/navigate.dart
@@ -1,10 +1,11 @@
 import 'refresh_timer.dart';
 
 class Navigate {
-  static void toRoute(Future<dynamic> route) {
+  /// Cancels the [RefreshTimer] and executes the provided navigation [action].
+  static Future<T?> toRoute<T>(Future<T?> Function() action) {
     if (RefreshTimer.refreshTimer != null) {
       RefreshTimer.refreshTimer!.cancel();
     }
-    route;
+    return action();
   }
 }


### PR DESCRIPTION
## Summary
- introduce an `AppInitializer` service for startup logic
- cancel timers via new `Navigate.toRoute` method
- update `DashboardScreen` navigation calls
- refactor `PlebLN` to a stateful widget using `AppInitializer`
- add `_executeRpc` helper and reduce duplication in `lnd.dart`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883b27ff0f88324ac90085049ff8ed4